### PR TITLE
Apply decorator before calling to_json

### DIFF
--- a/lib/active_admin/ajax_filter.rb
+++ b/lib/active_admin/ajax_filter.rb
@@ -15,8 +15,10 @@ module ActiveAdmin
         dsl.instance_eval do
           collection_action :filter, method: :get do
             scope = collection.ransack(params[:q]).result
+            scope = scope.order(params[:order]).limit(params[:limit] || 10)
+            scope = apply_collection_decorator(scope)
 
-            render text: scope.order(params[:order]).limit(params[:limit] || 10).to_json
+            render text: scope.to_json
           end
         end
       end

--- a/lib/active_admin/ajax_filter.rb
+++ b/lib/active_admin/ajax_filter.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
             scope = scope.order(params[:order]).limit(params[:limit] || 10)
             scope = apply_collection_decorator(scope)
 
-            render text: scope.to_json
+            render plain: scope.to_json
           end
         end
       end


### PR DESCRIPTION
In my particular case, I need to return a value to the ajax autocomplete on an associated object, which is not a default value for to_json. I do not wish to specify an as_json on my model, just to have an autocomplete work a certain way.

ActiveAdmin provides a [decorate_with option](http://activeadmin.info/docs/11-decorators.html).

So I have a decorator with as_json defined, which can be whatever I want.

To get it to work with this project, I tapped into ActiveAdmin's DataAccess method, [apply_collection_decorator](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_controller/data_access.rb#L29)

Let me know if you have any other ways to solve this problem. Thanks!

This it not related to my change, but while I was in there, I noticed that ransack params are actually being applied twice, once by the [apply_filtering](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_controller/data_access.rb#L224) method that is actually called behind the [collection method](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource_controller/data_access.rb#L55), and then once again right above the lines in my change below.