### PR TITLE
Respect static ransack predicate on first load

### DIFF
--- a/lib/active_admin/inputs/ajax_core.rb
+++ b/lib/active_admin/inputs/ajax_core.rb
@@ -30,7 +30,7 @@ module ActiveAdmin
       end
 
       def collection_from_association
-        super.try(:limit, collection_limit)
+        super.try(:limit, collection_limit).try(:ransack, static_ransack).result
       end
 
       def value_field


### PR DESCRIPTION
On page render, ajax input always does `Resource.all.limit(param_value)` query to fetch initial set of suggestions. It ignores `static_ransack` parameter. `static_ransack` if specified, should be merged with collection fetch in all cases.