### PR TITLE
Collection filter action should not fail when collection is decorated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in activeadmin-ajax_filter.gemspec
 gemspec
+gem 'draper', group: 'test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,11 @@ GEM
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    draper (2.1.0)
+      actionpack (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      request_store (~> 1.0)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.5.0)
@@ -179,6 +184,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -244,6 +251,7 @@ DEPENDENCIES
   capybara (~> 2.1)
   codeclimate-test-reporter (~> 0.4)
   database_cleaner (~> 1.5.0)
+  draper
   factory_girl_rails
   launchy (~> 2.4.3)
   phantomjs (~> 2.1.1)
@@ -256,4 +264,4 @@ DEPENDENCIES
   temping (~> 3.3, >= 3.3.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.2

--- a/lib/active_admin/ajax_filter.rb
+++ b/lib/active_admin/ajax_filter.rb
@@ -14,10 +14,10 @@ module ActiveAdmin
       def included(dsl)
         dsl.instance_eval do
           collection_action :filter, method: :get do
-            scope = collection.order(params[:order]).limit(params[:limit] || 10)
-            scope = apply_collection_decorator(scope)
-
-            render plain: scope.to_json
+            render plain: apply_collection_decorator(
+              find_collection(except: [:pagination, :collection_decorator])
+                .order(params[:order]).limit(params[:limit] || 10),
+            ).to_json
           end
         end
       end

--- a/spec/dummy/app/admin/subcategories.rb
+++ b/spec/dummy/app/admin/subcategories.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register Subcategory do
   include ActiveAdmin::AjaxFilter
+  decorate_with SubcategoryDecorator.name
 
   permit_params :id, :name, :category_id
   config.sort_order = 'id_asc'

--- a/spec/dummy/app/decorators/subcategory_decorator.rb
+++ b/spec/dummy/app/decorators/subcategory_decorator.rb
@@ -1,0 +1,3 @@
+class SubcategoryDecorator < Draper::Decorator
+  delegate_all
+end


### PR DESCRIPTION
Before:

```
NoMethodError: undefined method `order' for #<#<Class:0x007ff2cc6c5518>:0x007ff2cbc0fab0>
./lib/active_admin/ajax_filter.rb:17:in `block (2 levels) in included'
```