### PR TITLE
Consider the closest fieldset rather than the form.

### DIFF
--- a/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
+++ b/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
@@ -36,7 +36,7 @@ $ ->
             callback(res)
 
       relatedInput = (field) ->
-        $("[name*=#{field}]", select.parents('form'))
+        $("[name*=#{field}]", select.parents('fieldset'))
 
       isCircularAjaxSearchLink = (initial_input_id, field) ->
         input = relatedInput(field)


### PR DESCRIPTION
Issue Faced:
  Have a form with nested attributes. The nested form has 3 fields named grade, resource_type and resource_id. The resource_id is the field which is using activeadmin_ajax_filters and is expected to pass the selected grade and resource_type to get the result for the resource_id. This works correctly for the first nested attribute. But from the second case onwards, even if different values are selected for the grade and resource_type(compared to first nested attribute), the params passed is still the values from the first nested attribute

Example: 
   Nested Attribute 1:
      grade : 10
      resource_type: 'Video'
      resource_id: 123
params passed looks like 
{"q"=>{"identifier_or_description_cont"=>"123", "grade_eq"=>"10", "resource_type_eq"=>"Video"}, "limit"=>"10", "order"=>"identifier ASC"}

Nested Attribute 2
  grade : 9
  resource_type: 'Book'
  resource_id: '234'
The params looks like
{"q"=>{"identifier_or_description_cont"=>"234", "grade_eq"=>"10", "resource_type_eq"=>"Video"}, "limit"=>"10", "order"=>"identifier ASC"}

The fix done here looks for the closest fieldset rather that the form itself as is the current case. The current code works perfectly in the normal scenario where one would pass the form(not nested form) attributes as ajax_filters and they have only single occurance in the form compared to multiple occurances of the nested form attributes.