### PR TITLE
Selectize `closeAfterSelect` Setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ You can use next parameters in `data` hash:
 * `ajax_search_fields` - array of field names. `ajax_select` input depends on `ajax_search_fields` values: e.g. you can scope user by languages.
 * `static_ransack` - hash of ransack predicates which will be applied statically and independently from current input field value
 * `min_chars_count_to_request` - minimal count of chars in the input field to make an AJAX request
+* `placeholder` - input field placeholder.
+* `close_after_select` - close search results drop-down after selected a value. Default is `false`.
 
 ### Filter by belongs_to relation fields
 

--- a/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
+++ b/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
@@ -7,6 +7,7 @@ $ ->
     $('.filter_ajax_select select, .ajax_select select').each (_, select) ->
       select = $(select)
       valueField = select.data('value-field')
+      closeAfterSelect = select.data('close-after-select') || false
       display_fields = select.data('display-fields').split(' ')
       searchFields = select.data('search-fields').split(' ')
       staticRansack = select.data('static-ransack')
@@ -49,6 +50,7 @@ $ ->
       select.selectize
         valueField: valueField
         labelField: display_fields[0]
+        closeAfterSelect: closeAfterSelect
         placeholder: placeholder
         searchField: searchFields
         sortField: ordering.split(',').map (clause)->

--- a/lib/active_admin/inputs/ajax_core.rb
+++ b/lib/active_admin/inputs/ajax_core.rb
@@ -20,6 +20,8 @@ module ActiveAdmin
           'data-selected-value' => selected_value,
           'data-url' => url,
           'data-min-chars-count-to-request' => min_chars_count_to_request,
+          'data-placeholder' => placeholder,
+          'data-close-after-select' => close_after_select
         )
       end
 
@@ -65,6 +67,14 @@ module ActiveAdmin
 
       def min_chars_count_to_request
         ajax_data[:min_chars_count_to_request] || 1
+      end
+
+      def placeholder
+        ajax_data[:placeholder]
+      end
+
+      def close_after_select
+        ajax_data[:close_after_select] || false
       end
 
       def ransackify(field_names)


### PR DESCRIPTION
## Context
I would like to be able to configure selectize `closeAfterSelect` setting.

## Change
Pass `closeAfterSetting` from `data` attribute to `selectize` initialization.

Default is set to `false` as per `selectize` documentation.

## Reference
https://github.com/taufek/selectize.js/blob/master/docs/usage.md#general